### PR TITLE
Fixes a bug that would prevent replacing multiple placeholders in a single string

### DIFF
--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -34,14 +34,14 @@ var  rmDir = function(dirPath) {
 module.exports = function(grunt) {
 
     var replacePlaceholder = function(string, openingMark, closingMark,altEnabled){
-        if (closingMark !== undefined &&
-            altEnabled &&
-           string.indexOf(closingMark !== -1)){
+        if (closingMark !== undefined && altEnabled && string.indexOf(closingMark !== -1)) {
             if (string.indexOf(openingMark) !== -1){
-                string = string.replace(openingMark,"{{");
+                var regexp = new RegExp(openingMark, 'g');
+                string = string.replace(regexp, "{{");
             }
             if (string.indexOf(closingMark) !== -1){
-                string = string.replace(closingMark,"}}");
+                var regexp = new RegExp(closingMark, 'g');
+                string = string.replace(regexp, "}}");
             }
         }
 


### PR DESCRIPTION
Example string in .po file:

msgid: "EXAMPLE_ID“
msgstr: "This is a sample with not {replace_one}, not {replace_two}, but {replace_three} placeholders“

OLD: Would be incorrectly parsed, therefore only {replace_one} is handled by angular-translate
NEW: Fixes incorrect parsing, so that all three placeholders in the above example may be handled by angular-translate
