### PR TITLE
Feature/replace nodepo for pofile

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-jshint": "0.6.0",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-nodeunit": "0.2.0",
-    "grunt": "0.4.2",
+    "grunt": "0.4.2"
   },
   "peerDependencies": {
     "grunt": "0.4.2"

--- a/package.json
+++ b/package.json
@@ -28,19 +28,19 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.2"
+    "grunt-contrib-jshint": "0.6.0",
+    "grunt-contrib-clean": "0.4.0",
+    "grunt-contrib-nodeunit": "0.2.0",
+    "grunt": "0.4.2",
   },
   "peerDependencies": {
-      "grunt": "~0.4.2"
+    "grunt": "0.4.2"
   },
-    "dependencies": {
-        "node-po": "~0.1.2",
-        "path"  : "~0.4.9"
-    },
-    "keywords": [
-        "gruntplugin"
-    ]
+  "dependencies": {
+    "pofile": "0.2.12",
+    "path": "0.4.9"
+  },
+  "keywords": [
+    "gruntplugin"
+  ]
 }

--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var po = require('node-po');
+var po = require('pofile');
 var path = require('path');
 var fs = require('fs');
 

--- a/test/fixtures/button.po
+++ b/test/fixtures/button.po
@@ -12,8 +12,8 @@ msgstr ""
 msgid "button/submit"
 msgstr "Submit %d"
 
-#msgid "button/save-change"
-#msgstr "Save Change"
+#: msgid "button/save-change"
+#: msgstr "Save Change"
 
 msgid "button/save-change"
 msgid_plural "button/save-changes"

--- a/test/po2json_angular_translate_test.js
+++ b/test/po2json_angular_translate_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var grunt = require('grunt');
-var po = require('node-po');
+var po = require('pofile');
 
 
 /*
@@ -32,7 +32,8 @@ exports.po2json_angular_translate = {
         test.expect(1);
 
         var generated = grunt.file.read('tmp/button.json');
-        var expected = grunt.file.read('test/expected/button.json');
+        //git adds the CRLF meanwhile the grunt doesn't, so we remove the \r
+        var expected = grunt.file.read('test/expected/button.json').replace(/\r\n/g, '\n');
 
         test.strictEqual(generated, expected, 'Should be the same JSON objext, just msgid and msgstr.');
 


### PR DESCRIPTION
Replaced node-po for pofile as suggested in #6. Now the program handled correctly the CRLF in Windows. 

Also I have fixed the versions of dependencies.
