### PR TITLE
Multiple placeholders are handled properly

### DIFF
--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -33,15 +33,24 @@ var  rmDir = function(dirPath) {
 
 module.exports = function(grunt) {
 
-    var replacePlaceholder = function(string, openingMark, closingMark,altEnabled){
+    var replacePlaceholder = function(string, openingMark, closingMark,altEnabled, isPluralString){
         if (closingMark !== undefined &&
             altEnabled &&
            string.indexOf(closingMark !== -1)){
             if (string.indexOf(openingMark) !== -1){
-                string = string.replace(openingMark,"{{");
+                if (isPluralString) {
+                    string = string.replace(openingMark,"{{");
+                } else {
+                    string = string.replace(new RegExp(openingMark, 'g'),"{{");
+                }
+                
             }
             if (string.indexOf(closingMark) !== -1){
-                string = string.replace(closingMark,"}}");
+                if (isPluralString) {
+                    string = string.replace(closingMark,"}}");
+                } else {
+                    string = string.replace(new RegExp(closingMark, 'g'),"}}");
+                }
             }
         }
 
@@ -159,7 +168,7 @@ module.exports = function(grunt) {
                             }
                         }
 
-                        pluralizedStr = replacePlaceholder(pluralizedStr,options.placeholderStructure[0],options.placeholderStructure[1],options.enableAltPlaceholders);
+                        pluralizedStr = replacePlaceholder(pluralizedStr,options.placeholderStructure[0],options.placeholderStructure[1],options.enableAltPlaceholders, true);
                         strings[item.msgid] = pluralizedStr ;
                         if (singleFile){
                             singleFileStrings[item.msgid]=  pluralizedStr;

--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -38,10 +38,10 @@ module.exports = function(grunt) {
             altEnabled &&
            string.indexOf(closingMark !== -1)){
             if (string.indexOf(openingMark) !== -1){
-                string = string.replace(openingMark,"{{");
+                string = string.replace(new RegExp(openingMark, 'g'),"{{");
             }
             if (string.indexOf(closingMark) !== -1){
-                string = string.replace(closingMark,"}}");
+                string = string.replace(new RegExp(closingMark, 'g'),"}}");
             }
         }
 

--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -38,10 +38,10 @@ module.exports = function(grunt) {
             altEnabled &&
            string.indexOf(closingMark !== -1)){
             if (string.indexOf(openingMark) !== -1){
-                string = string.replace(new RegExp(openingMark, 'g'),"{{");
+                string = string.replace(openingMark,"{{");
             }
             if (string.indexOf(closingMark) !== -1){
-                string = string.replace(new RegExp(closingMark, 'g'),"}}");
+                string = string.replace(closingMark,"}}");
             }
         }
 

--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -38,12 +38,12 @@ module.exports = function(grunt) {
         if (closingMark !== undefined &&
             altEnabled &&
            string.indexOf(closingMark !== -1)){
-            if (string.indexOf(openingMark) !== -1){
-                pattern = isPluralString ? openingMark : new RegExp(openingMark, 'g');
+            if (string.indexOf(openingMark) !== -1 && !isPluralString){
+                pattern = new RegExp(openingMark, 'g');
                 string = string.replace(pattern,"{{");
             }
-            if (string.indexOf(closingMark) !== -1){
-                pattern = isPluralString ? closingMark : new RegExp(closingMark, 'g');
+            if (string.indexOf(closingMark) !== -1 && !isPluralString){
+                pattern = new RegExp(closingMark, 'g');
                 string = string.replace(pattern,"}}");
             }
         }

--- a/tasks/po2json_angular_translate.js
+++ b/tasks/po2json_angular_translate.js
@@ -34,29 +34,23 @@ var  rmDir = function(dirPath) {
 module.exports = function(grunt) {
 
     var replacePlaceholder = function(string, openingMark, closingMark,altEnabled, isPluralString){
+        var pattern;
         if (closingMark !== undefined &&
             altEnabled &&
            string.indexOf(closingMark !== -1)){
             if (string.indexOf(openingMark) !== -1){
-                if (isPluralString) {
-                    string = string.replace(openingMark,"{{");
-                } else {
-                    string = string.replace(new RegExp(openingMark, 'g'),"{{");
-                }
-                
+                pattern = isPluralString ? openingMark : new RegExp(openingMark, 'g');
+                string = string.replace(pattern,"{{");
             }
             if (string.indexOf(closingMark) !== -1){
-                if (isPluralString) {
-                    string = string.replace(closingMark,"}}");
-                } else {
-                    string = string.replace(new RegExp(closingMark, 'g'),"}}");
-                }
+                pattern = isPluralString ? closingMark : new RegExp(closingMark, 'g');
+                string = string.replace(pattern,"}}");
             }
         }
 
          //If there is no closing mark, then we have standard format: %0,
         if(string.indexOf(closingMark === -1)){
-            var pattern ="\\%([0-9]|[a-z])";
+            pattern ="\\%([0-9]|[a-z])";
             var re = new RegExp(pattern,"g");
             var index = string.indexOf(re);
             var substr = string.substr(index,index+2);

--- a/test/expected/button.json
+++ b/test/expected/button.json
@@ -2,5 +2,6 @@
    "button/submit": "Submit {{d}}",
    "button/save-change": "Save {{PLURALIZE, plural, offset:1 =2{# Change}} other{# Changes}}",
    "button/register": "Register {{0}}",
-   "button/delete-account": "Delete Account"
+   "button/delete-account": "Delete Account",
+   "button/multiple-placeholder": "Delete {{ account }} for {{ user }}"
 }

--- a/test/expected/button.json
+++ b/test/expected/button.json
@@ -1,6 +1,6 @@
 {
    "button/submit": "Submit {{d}}",
-   "button/save-change": "Save {{PLURALIZE, plural, offset:1 =2{# Change}} other{# Changes}}",
+   "button/save-change": "Save {PLURALIZE, plural, offset:1 =2{# Change} other{# Changes}}",
    "button/register": "Register {{0}}",
    "button/delete-account": "Delete Account",
    "button/multiple-placeholder": "Delete {{ account }} for {{ user }}"

--- a/test/expected/several.json
+++ b/test/expected/several.json
@@ -1,6 +1,6 @@
 {
    "button/submit": "Submit {{d}}",
-   "button/save-change": "Save {{PLURALIZE, plural, offset:1 =2{# Change}} other{# Changes}}",
+   "button/save-change": "Save {PLURALIZE, plural, offset:1 =2{# Change} other{# Changes}}",
    "button/register": "Register {{0}}",
    "button/delete-account": "Delete Account",
    "[:message/maintenance :title]": "Maintenance",

--- a/test/fixtures/button.po
+++ b/test/fixtures/button.po
@@ -25,3 +25,6 @@ msgstr "Register {0}"
 
 msgid "button/delete-account"
 msgstr "Delete Account"
+
+msgid "button/multiple-placeholder"
+msgstr "Delete { account } for { user }"


### PR DESCRIPTION
This change allows strings to contain multiple placeholders.
For example, the following entry in the PO file:
```
msgid "button/multiple-placeholder"
msgstr "Delete { account } for { user }"
```
is translated to the JSON file into
```
"button/multiple-placeholder": "Delete {{ account }} for {{ user }}"
```
Before it translated to
```
"button/multiple-placeholder": "Delete {{ account }} for { user }"
```
So "user" was missing the double curly braces.

Furthermore, pluralized strings are handled correctly by not replacing the openingMark and closingMark at all.

For example
```
msgid "button/save-change"
msgid_plural "button/save-changes"
msgstr[0] "Save %d Change"
msgstr[1] "Save %d Changes"
```
is translated properly to
```
"button/save-change": "Save {PLURALIZE, plural, offset:1 =2{# Change} other{# Changes}}",
```
